### PR TITLE
Do not traverse through git repositories

### DIFF
--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -101,9 +102,18 @@ func (r *RepoFinder) Find() ([]string, error) {
 }
 
 func (r *RepoFinder) walkCb(path string, ent *godirwalk.Dirent) error {
+	// Do not traverse .git directories
 	if ent.IsDir() && ent.Name() == ".git" {
 		r.repos = append(r.repos, strings.TrimSuffix(path, ".git"))
 		return ErrSkipNode
+	}
+	// Do not traverse directories containing a .git directory
+	if ent.IsDir() {
+		_, err := os.Stat(filepath.Join(path, ".git"))
+		if err == nil {
+			r.repos = append(r.repos, strings.TrimSuffix(path, ".git"))
+			return ErrSkipNode
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This makes `git list` a lot faster (10 minutes to under 2 minutes in one test) and displays more useful information (at least to me).

Example of `git list` from before this change demonstrating that `git list` was hiding the information about the main repository in favour of showing information about a `composer` dependency:

```
├── iguana-extras
│   └── vendor
│       └── dxw
│           └── iguana HEAD ok
│                      master ok
```

Example from after this change:

```
├── iguana-extras master  [ 1 untracked ]
│                 feature/readme no upstream
│                 feature/update-iguana no upstream
│                 fix/php-cs-fixer no upstream
```