### PR TITLE
Add --skip-host flag to get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Flags:
   -h, --help                Print this help and exit.
   -t, --host                Host to use when <REPO> doesn't have a specified host. (default "github.com")
   -r, --root                Path to repos root where repositories are cloned. (default "~/repositories")
+  -s, --skip-host           Don't create a directory for host.
   -v, --version             Print version and exit.
 ```
 
@@ -143,11 +144,14 @@ export GITGET_ROOT=/path/to/my/repos
 
 You can define a `[gitget]` section inside your global `.gitconfig` file and set the configuration flags there. A recommended pattern is to set `root` and `host` variables there if you don't want to use the defaults. 
 
+If all of your repos come from the same host and you find creating directory for it redundant, you can use the `skip-host` flag to skip creating it.
+
 Here's an example of a working snippet from `.gitconfig` file:
 ```
 [gitget]
     root = /path/to/my/repos
     host = gitlab.com
+    skip-host = true
 ```
 
 

--- a/cmd/get/main.go
+++ b/cmd/get/main.go
@@ -28,6 +28,7 @@ func init() {
 	cmd.PersistentFlags().StringP(cfg.KeyBranch, "b", "", "Branch (or tag) to checkout after cloning.")
 	cmd.PersistentFlags().StringP(cfg.KeyDefaultHost, "t", cfg.Defaults[cfg.KeyDefaultHost], "Host to use when <REPO> doesn't have a specified host.")
 	cmd.PersistentFlags().StringP(cfg.KeyDump, "d", "", "Path to a dump file listing repos to clone. Ignored when <REPO> argument is used.")
+	cmd.PersistentFlags().BoolP(cfg.KeySkipHost, "s", false, "Don't create a directory for host.")
 	cmd.PersistentFlags().StringP(cfg.KeyReposRoot, "r", cfg.Defaults[cfg.KeyReposRoot], "Path to repos root where repositories are cloned.")
 	cmd.PersistentFlags().BoolP("help", "h", false, "Print this help and exit.")
 	cmd.PersistentFlags().BoolP("version", "v", false, "Print version and exit.")
@@ -36,6 +37,7 @@ func init() {
 	viper.BindPFlag(cfg.KeyDefaultHost, cmd.PersistentFlags().Lookup(cfg.KeyDefaultHost))
 	viper.BindPFlag(cfg.KeyDump, cmd.PersistentFlags().Lookup(cfg.KeyDump))
 	viper.BindPFlag(cfg.KeyReposRoot, cmd.PersistentFlags().Lookup(cfg.KeyReposRoot))
+	viper.BindPFlag(cfg.KeySkipHost, cmd.PersistentFlags().Lookup(cfg.KeySkipHost))
 
 	cfg.Init(&git.ConfigGlobal{})
 }
@@ -49,11 +51,12 @@ func run(cmd *cobra.Command, args []string) error {
 	cfg.Expand(cfg.KeyReposRoot)
 
 	config := &pkg.GetCfg{
-		Branch:  viper.GetString(cfg.KeyBranch),
-		DefHost: viper.GetString(cfg.KeyDefaultHost),
-		Dump:    viper.GetString(cfg.KeyDump),
-		Root:    viper.GetString(cfg.KeyReposRoot),
-		URL:     url,
+		Branch:   viper.GetString(cfg.KeyBranch),
+		DefHost:  viper.GetString(cfg.KeyDefaultHost),
+		Dump:     viper.GetString(cfg.KeyDump),
+		SkipHost: viper.GetBool(cfg.KeySkipHost),
+		Root:     viper.GetString(cfg.KeyReposRoot),
+		URL:      url,
 	}
 	return pkg.Get(config)
 }

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -22,6 +22,7 @@ var (
 	KeyDefaultHost = "host"
 	KeyFetch       = "fetch"
 	KeyOutput      = "out"
+	KeySkipHost    = "skip-host"
 	KeyReposRoot   = "root"
 )
 
@@ -30,6 +31,7 @@ var Defaults = map[string]string{
 	KeyDefaultHost: "github.com",
 	KeyOutput:      OutTree,
 	KeyReposRoot:   fmt.Sprintf("~%c%s", filepath.Separator, "repositories"),
+	// KeySkipHost:    "false",
 }
 
 // Values for the --out flag.
@@ -78,6 +80,7 @@ func Init(cfg Gitconfig) {
 func readGitconfig(cfg Gitconfig) {
 	var lines []string
 
+	// TODO: Can we somehow iterate over all possible flags?
 	for key := range Defaults {
 		if val := cfg.Get(fmt.Sprintf("%s.%s", GitgetPrefix, key)); val != "" {
 			lines = append(lines, fmt.Sprintf("%s=%s", key, val))
@@ -86,6 +89,11 @@ func readGitconfig(cfg Gitconfig) {
 
 	viper.SetConfigType("env")
 	viper.ReadConfig(bytes.NewBuffer([]byte(strings.Join(lines, "\n"))))
+
+	// TODO: A hacky way to read boolean flag from gitconfig. Find a cleaner way.
+	if val := cfg.Get(fmt.Sprintf("%s.%s", GitgetPrefix, KeySkipHost)); strings.ToLower(val) == "true" {
+		viper.Set(KeySkipHost, true)
+	}
 }
 
 // Expand applies the variables expansion to a viper config of given key.

--- a/pkg/get.go
+++ b/pkg/get.go
@@ -9,11 +9,12 @@ import (
 
 // GetCfg provides configuration for the Get command.
 type GetCfg struct {
-	Branch  string
-	DefHost string
-	Dump    string
-	Root    string
-	URL     string
+	Branch   string
+	DefHost  string
+	Dump     string
+	Root     string
+	SkipHost bool
+	URL      string
 }
 
 // Get executes the "git get" command.
@@ -40,7 +41,7 @@ func cloneSingleRepo(c *GetCfg) error {
 
 	opts := &git.CloneOpts{
 		URL:    url,
-		Path:   filepath.Join(c.Root, URLToPath(url)),
+		Path:   filepath.Join(c.Root, URLToPath(*url, c.SkipHost)),
 		Branch: c.Branch,
 	}
 
@@ -63,7 +64,7 @@ func cloneDumpFile(c *GetCfg) error {
 
 		opts := &git.CloneOpts{
 			URL:    url,
-			Path:   filepath.Join(c.Root, URLToPath(url)),
+			Path:   filepath.Join(c.Root, URLToPath(*url, c.SkipHost)),
 			Branch: line.branch,
 		}
 


### PR DESCRIPTION
When set, git-get won't create a directory for the repo host.
So instead of `<root>/<host>/<user>/<repo>`, a repo will be cloned into `<root>/<user>/<repo>`.
It's useful if all repos some from the same host and that additional folder feels redundant.