### PR TITLE
Improve error messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0
-	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	github.com/xlab/treeprint v1.0.0
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/pkg/git/finder.go
+++ b/pkg/git/finder.go
@@ -16,8 +16,8 @@ import (
 // It's handled by ErrorsCallback to tell the WalkCallback to skip this dir.
 var errSkipNode = errors.New(".git directory found, skipping this node")
 
-// errDirectoryAccess indicates a directory doesn't exists or can't be accessed
-var errDirectoryAccess = errors.New("directory doesn't exist or can't be accessed")
+var errDirNoAccess = errors.New("directory can't be accessed")
+var errDirNotExist = errors.New("directory doesn't exist")
 
 // Exists returns true if a directory exists. If it doesn't or the directory can't be accessed it returns an error.
 func Exists(path string) (bool, error) {
@@ -29,12 +29,12 @@ func Exists(path string) (bool, error) {
 
 	if err != nil {
 		if os.IsNotExist(err) {
-			return false, errDirectoryAccess
+			return false, errors.Wrapf(errDirNotExist, "can't access %s", path)
 		}
 	}
 
 	// Directory exists but can't be accessed
-	return true, errDirectoryAccess
+	return true, errors.Wrapf(errDirNoAccess, "can't access %s", path)
 }
 
 // RepoFinder finds git repositories inside a given path.

--- a/pkg/git/finder_test.go
+++ b/pkg/git/finder_test.go
@@ -1,8 +1,11 @@
 package git
 
 import (
+	"errors"
 	"git-get/pkg/git/test"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFinder(t *testing.T) {
@@ -15,18 +18,15 @@ func TestFinder(t *testing.T) {
 			name:       "no repos",
 			reposMaker: makeNoRepos,
 			want:       0,
-		},
-		{
+		}, {
 			name:       "single repos",
 			reposMaker: makeSingleRepo,
 			want:       1,
-		},
-		{
+		}, {
 			name:       "single nested repo",
 			reposMaker: makeNestedRepo,
 			want:       1,
-		},
-		{
+		}, {
 			name:       "multiple nested repo",
 			reposMaker: makeMultipleNestedRepos,
 			want:       2,
@@ -40,9 +40,38 @@ func TestFinder(t *testing.T) {
 			finder := NewRepoFinder(root)
 			finder.Find()
 
-			if len(finder.repos) != test.want {
-				t.Errorf("expected %d; got %d", test.want, len(finder.repos))
-			}
+			assert.Len(t, finder.repos, test.want)
+		})
+	}
+}
+
+// TODO: this test will only work on Linux
+func TestExists(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want error
+	}{
+		{
+			name: "dir does not exist",
+			path: "/this/directory/does/not/exist",
+			want: errDirNotExist,
+		}, {
+			name: "dir cant be accessed",
+			path: "/root/some/directory",
+			want: errDirNoAccess,
+		}, {
+			name: "dir exists",
+			path: "/tmp/",
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Exists(test.path)
+
+			assert.True(t, errors.Is(err, test.want))
 		})
 	}
 }

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -6,14 +6,6 @@ import (
 	"testing"
 )
 
-func TestOpen(t *testing.T) {
-	_, err := Open("/paththatdoesnotexist/repo")
-
-	if err != errDirectoryAccess {
-		t.Errorf("Opening a repo in non existing path should throw an error")
-	}
-}
-
 func TestUncommitted(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/list.go
+++ b/pkg/list.go
@@ -30,11 +30,11 @@ func List(c *ListCfg) error {
 
 	switch c.Output {
 	case cfg.OutFlat:
-		fmt.Println(print.NewFlatPrinter().Print(printables))
+		fmt.Print(print.NewFlatPrinter().Print(printables))
 	case cfg.OutTree:
-		fmt.Println(print.NewTreePrinter().Print(c.Root, printables))
+		fmt.Print(print.NewTreePrinter().Print(c.Root, printables))
 	case cfg.OutDump:
-		fmt.Println(print.NewDumpPrinter().Print(printables))
+		fmt.Print(print.NewDumpPrinter().Print(printables))
 	default:
 		return fmt.Errorf("invalid --out flag; allowed values: [%s]", strings.Join(cfg.AllowedOut, ", "))
 	}

--- a/pkg/print/dump.go
+++ b/pkg/print/dump.go
@@ -17,7 +17,7 @@ func NewDumpPrinter() *DumpPrinter {
 func (p *DumpPrinter) Print(repos []Printable) string {
 	var str strings.Builder
 
-	for i, r := range repos {
+	for _, r := range repos {
 		str.WriteString(r.Remote())
 
 		// TODO: if head is detached maybe we should get the revision it points to in case it's a tag
@@ -25,9 +25,7 @@ func (p *DumpPrinter) Print(repos []Printable) string {
 			str.WriteString(" " + current)
 		}
 
-		if i < len(repos)-1 {
-			str.WriteString("\n")
-		}
+		str.WriteString("\n")
 	}
 
 	return str.String()

--- a/pkg/print/flat.go
+++ b/pkg/print/flat.go
@@ -18,8 +18,14 @@ func NewFlatPrinter() *FlatPrinter {
 func (p *FlatPrinter) Print(repos []Printable) string {
 	var str strings.Builder
 
-	for i, r := range repos {
+	for _, r := range repos {
 		str.WriteString(strings.TrimSuffix(r.Path(), string(os.PathSeparator)))
+
+		if len(r.Errors()) > 0 {
+			str.WriteString(" " + red("error") + "\n")
+			continue
+		}
+
 		str.WriteString(" " + blue(r.Current()))
 
 		current := r.BranchStatus(r.Current())
@@ -45,10 +51,8 @@ func (p *FlatPrinter) Print(repos []Printable) string {
 			str.WriteString(fmt.Sprintf("\n%s %s %s", indent, blue(branch), yellow(status)))
 		}
 
-		if i < len(repos)-1 {
-			str.WriteString("\n")
-		}
+		str.WriteString("\n")
 	}
 
-	return str.String()
+	return str.String() + Errors(repos)
 }

--- a/pkg/print/print.go
+++ b/pkg/print/print.go
@@ -1,6 +1,9 @@
 package print
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	head = "HEAD"
@@ -15,6 +18,28 @@ type Printable interface {
 	WorkTreeStatus() string
 	Remote() string
 	Errors() []string
+}
+
+// Errors returns a printable list of errors from the slice of Printables or an empty string if there are no errors.
+// It's meant to be appended at the end of Print() result.
+func Errors(repos []Printable) string {
+	errors := []string{}
+
+	for _, repo := range repos {
+		for _, err := range repo.Errors() {
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) == 0 {
+		return ""
+	}
+
+	var str strings.Builder
+	str.WriteString(red("\nOops, errors happened when loading repository status:\n"))
+	str.WriteString(strings.Join(errors, "\n"))
+
+	return str.String()
 }
 
 // TODO: not sure if this works on windows. See https://github.com/mattn/go-colorable


### PR DESCRIPTION
This improves error handling by:
- indicating that error happened when loading status of a repository
- printing errors that happened at the bottom of the output
- Fixing #10 by adding path to the error message