### PR TITLE
Bump Go version to 1.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       - name: Set up Git
         run: git config --global user.email "grdl@example.com" && git config --global user.name "grdl"
       - name: Run go test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
Hey there,
I just got my M1 MacBook Air and wanted to use `git-get` and installed it using the instructions in its README. Unfortunately the binary that is being downloaded is compiled for x86_64 which when run prints the error message 

```
fatal: cannot exec 'git-get': Bad CPU type in executable
```

That only happens if Rosetta 2 is not installed on the Mac. After installing Rosetta 2 it works in emulated mode.

Since `git-get` is a Go program it can be compiled as a native binary for Apple Silicon.

I saw that you use GoReleaser for builds and releases. GoReleaser v0.157.0 released on 2021-02-17 will build a fitting binary automatically as long as Go 1.16 is used. This should be enough to get `git-get` working on Apple Silicon.

Would you mind rebuilding the project to upload a binary for others to use as well? :)