### PR TITLE
For tree output format print out branch description if available

### DIFF
--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -2,12 +2,13 @@ package git
 
 import (
 	"fmt"
-	"git-get/pkg/run"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"git-get/pkg/run"
 )
 
 const (
@@ -144,6 +145,16 @@ func (r *Repo) Upstream(branch string) (string, error) {
 		return "", nil
 	}
 
+	return out, nil
+}
+
+// Description returns description of a branch if a given branch has one set with "git branch --edit-description".
+// Otherwise it returns an empty slice.
+func (r *Repo) Description(branch string) ([]string, error) {
+	out, err := run.Git("config", fmt.Sprintf("branch.%s.description", branch)).OnRepo(r.path).AndCaptureLines()
+	if err != nil {
+		return nil, nil
+	}
 	return out, nil
 }
 

--- a/pkg/print/print.go
+++ b/pkg/print/print.go
@@ -15,6 +15,7 @@ type Printable interface {
 	Current() string
 	Branches() []string
 	BranchStatus(string) string
+	BranchDescription(string) []string
 	WorkTreeStatus() string
 	Remote() string
 	Errors() []string
@@ -57,4 +58,8 @@ func blue(str string) string {
 
 func yellow(str string) string {
 	return fmt.Sprintf("\033[1;33m%s\033[0m", str)
+}
+
+func magenta(str string) string {
+	return fmt.Sprintf("\033[1;35m%s\033[0m", str)
 }

--- a/pkg/print/tree.go
+++ b/pkg/print/tree.go
@@ -154,7 +154,7 @@ func printLeaf(node *Node) string {
 	if description := r.BranchDescription(r.Current()); len(description) > 0 {
 		for _, line := range description {
 			if len(line) > 0 {
-				str.WriteString(fmt.Sprintf("\n%s  %s", indentation(node), magenta(line)))
+				str.WriteString(fmt.Sprintf("\n%s┈ %s", indentation(node), magenta(line)))
 			}
 		}
 	}
@@ -170,7 +170,7 @@ func printLeaf(node *Node) string {
 		if description := r.BranchDescription(branch); len(description) > 0 {
 			for _, line := range description {
 				if len(line) > 0 {
-					str.WriteString(fmt.Sprintf("\n%s  %s", indentation(node), magenta(line)))
+					str.WriteString(fmt.Sprintf("\n%s┈ %s", indentation(node), magenta(line)))
 				}
 			}
 		}

--- a/pkg/print/tree.go
+++ b/pkg/print/tree.go
@@ -151,6 +151,14 @@ func printLeaf(node *Node) string {
 		str.WriteString(fmt.Sprintf("%s %s %s", node.val, blue(r.Current()), strings.Join([]string{yellow(current), red(worktree)}, " ")))
 	}
 
+	if description := r.BranchDescription(r.Current()); len(description) > 0 {
+		for _, line := range description {
+			if len(line) > 0 {
+				str.WriteString(fmt.Sprintf("\n%s  %s", indentation(node), magenta(line)))
+			}
+		}
+	}
+
 	for _, branch := range r.Branches() {
 		status := r.BranchStatus(branch)
 		if status == "" {
@@ -158,6 +166,14 @@ func printLeaf(node *Node) string {
 		}
 
 		str.WriteString(fmt.Sprintf("\n%s%s %s", indentation(node), blue(branch), yellow(status)))
+
+		if description := r.BranchDescription(branch); len(description) > 0 {
+			for _, line := range description {
+				if len(line) > 0 {
+					str.WriteString(fmt.Sprintf("\n%s  %s", indentation(node), magenta(line)))
+				}
+			}
+		}
 	}
 
 	return str.String()


### PR DESCRIPTION
Some local branches could have descriptions created by "git branch --edit-description". Descriptions are kept in local repository config and are available with "git config branch._branch_name_.description". This PR prints out available branch descriptions when "tree" format is specified. When working with many repositories with multiple branches this could be pretty useful.