### PR TITLE
feat: add support for multiple repository roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ git get <REPOSITORY> [flags]
 - `-b, --branch <name>` - Branch or tag to checkout after cloning
 - `-d, --dump <file>` - Clone multiple repositories from a dump file
 - `-t, --host <host>` - Default host for short repository names (default: github.com)
-- `-r, --root <path>` - Root directory for repositories (default: ~/repositories)
+- `-r, --root <path>` - Root directory for repositories. If multiple roots are configured, the first one is used for cloning. (default: ~/repositories)
 - `-c, --scheme <scheme>` - Default scheme for URLs (default: ssh)
 - `-s, --skip-host` - Skip creating host directory
 - `-h, --help` - Show help
@@ -195,7 +195,7 @@ git list [flags]
 **Flags:**
 - `-f, --fetch` - Fetch from remotes before listing
 - `-o, --out <format>` - Output format: tree, flat, or dump (default: tree)
-- `-r, --root <path>` - Root directory to scan (default: ~/repositories)
+- `-r, --root <path>` - Root directory to scan. Can be specified multiple times to scan multiple directories. (default: ~/repositories)
 - `-h, --help` - Show help
 - `-v, --version` - Show version
 
@@ -248,7 +248,8 @@ export GITGET_SKIP_HOST=true
 Add a `[gitget]` section to your global Git configuration:
 
 ```bash
-git config --global gitget.root /workspace/repositories
+git config --global --add gitget.root /workspace/repositories
+git config --global --add gitget.root /another/path
 git config --global gitget.host gitlab.com
 git config --global gitget.skip-host true
 ```
@@ -257,6 +258,7 @@ Or edit `~/.gitconfig` directly:
 ```ini
 [gitget]
     root = /workspace/repositories
+    root = /another/path
     host = gitlab.com
     skip-host = true
 ```

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -29,11 +29,11 @@ func newGetCommand() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringP(cfg.KeyBranch, "b", "", "Branch (or tag) to checkout after cloning.")
-	cmd.PersistentFlags().StringP(cfg.KeyDefaultHost, "t", cfg.Defaults[cfg.KeyDefaultHost], "Host to use when <REPO> doesn't have a specified host.")
-	cmd.PersistentFlags().StringP(cfg.KeyDefaultScheme, "c", cfg.Defaults[cfg.KeyDefaultScheme], "Scheme to use when <REPO> doesn't have a specified scheme.")
+	cmd.PersistentFlags().StringP(cfg.KeyDefaultHost, "t", cfg.Defaults.DefaultHost, "Host to use when <REPO> doesn't have a specified host.")
+	cmd.PersistentFlags().StringP(cfg.KeyDefaultScheme, "c", cfg.Defaults.DefaultScheme, "Scheme to use when <REPO> doesn't have a specified scheme.")
 	cmd.PersistentFlags().StringP(cfg.KeyDump, "d", "", "Path to a dump file listing repos to clone. Ignored when <REPO> argument is used.")
 	cmd.PersistentFlags().BoolP(cfg.KeySkipHost, "s", false, "Don't create a directory for host.")
-	cmd.PersistentFlags().StringP(cfg.KeyReposRoot, "r", cfg.Defaults[cfg.KeyReposRoot], "Path to repos root where repositories are cloned.")
+	cmd.PersistentFlags().StringSliceP(cfg.KeyReposRoot, "r", cfg.Defaults.ReposRoot, "Path to repos root where repositories are cloned.")
 	cmd.PersistentFlags().BoolP("help", "h", false, "Print this help and exit.")
 	cmd.PersistentFlags().BoolP("version", "v", false, "Print version and exit.")
 
@@ -52,13 +52,20 @@ func runGetCommand(_ *cobra.Command, args []string) error {
 
 	cfg.Expand(cfg.KeyReposRoot)
 
+	roots := viper.GetStringSlice(cfg.KeyReposRoot)
+
+	var root string
+	if len(roots) > 0 {
+		root = roots[0]
+	}
+
 	config := &pkg.GetCfg{
 		Branch:    viper.GetString(cfg.KeyBranch),
 		DefHost:   viper.GetString(cfg.KeyDefaultHost),
 		DefScheme: viper.GetString(cfg.KeyDefaultScheme),
 		Dump:      viper.GetString(cfg.KeyDump),
 		SkipHost:  viper.GetBool(cfg.KeySkipHost),
-		Root:      viper.GetString(cfg.KeyReposRoot),
+		Root:      root,
 		URL:       url,
 	}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -24,8 +24,8 @@ func newListCommand() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolP(cfg.KeyFetch, "f", false, "First fetch from remotes before listing repositories.")
-	cmd.PersistentFlags().StringP(cfg.KeyOutput, "o", cfg.Defaults[cfg.KeyOutput], fmt.Sprintf("Output format. Allowed values: [%s].", strings.Join(cfg.AllowedOut, ", ")))
-	cmd.PersistentFlags().StringP(cfg.KeyReposRoot, "r", cfg.Defaults[cfg.KeyReposRoot], "Path to repos root where repositories are cloned.")
+	cmd.PersistentFlags().StringP(cfg.KeyOutput, "o", cfg.Defaults.Output, fmt.Sprintf("Output format. Allowed values: [%s].", strings.Join(cfg.AllowedOut, ", ")))
+	cmd.PersistentFlags().StringSliceP(cfg.KeyReposRoot, "r", cfg.Defaults.ReposRoot, "Path to repos root where repositories are scanned.")
 	cmd.PersistentFlags().BoolP("help", "h", false, "Print this help and exit.")
 	cmd.PersistentFlags().BoolP("version", "v", false, "Print version and exit.")
 
@@ -42,7 +42,7 @@ func runListCommand(_ *cobra.Command, _ []string) error {
 	config := &pkg.ListCfg{
 		Fetch:  viper.GetBool(cfg.KeyFetch),
 		Output: viper.GetString(cfg.KeyOutput),
-		Root:   viper.GetString(cfg.KeyReposRoot),
+		Roots:  viper.GetStringSlice(cfg.KeyReposRoot),
 	}
 
 	return pkg.List(config)

--- a/docs/git-get.1
+++ b/docs/git-get.1
@@ -253,7 +253,7 @@ git get <REPOSITORY> [flags]
 - \fB-b, --branch <name>\fR - Branch or tag to checkout after cloning
 - \fB-d, --dump <file>\fR - Clone multiple repositories from a dump file
 - \fB-t, --host <host>\fR - Default host for short repository names (default: github.com)
-- \fB-r, --root <path>\fR - Root directory for repositories (default: ~/repositories)
+- \fB-r, --root <path>\fR - Root directory for repositories. If multiple roots are configured, the first one is used for cloning. (default: ~/repositories)
 - \fB-c, --scheme <scheme>\fR - Default scheme for URLs (default: ssh)
 - \fB-s, --skip-host\fR - Skip creating host directory
 - \fB-h, --help\fR - Show help
@@ -277,7 +277,7 @@ git list [flags]
 \fBFlags:\fP
 - \fB-f, --fetch\fR - Fetch from remotes before listing
 - \fB-o, --out <format>\fR - Output format: tree, flat, or dump (default: tree)
-- \fB-r, --root <path>\fR - Root directory to scan (default: ~/repositories)
+- \fB-r, --root <path>\fR - Root directory to scan. Can be specified multiple times to scan multiple directories. (default: ~/repositories)
 - \fB-h, --help\fR - Show help
 - \fB-v, --version\fR - Show version
 
@@ -333,7 +333,8 @@ export GITGET_SKIP_HOST=true
 Add a \fB[gitget]\fR section to your global Git configuration:
 
 .EX
-git config --global gitget.root /workspace/repositories
+git config --global --add gitget.root /workspace/repositories
+git config --global --add gitget.root /another/path
 git config --global gitget.host gitlab.com
 git config --global gitget.skip-host true
 .EE
@@ -344,6 +345,7 @@ Or edit \fB~/.gitconfig\fR directly:
 .EX
 [gitget]
     root = /workspace/repositories
+    root = /another/path
     host = gitlab.com
     skip-host = true
 .EE

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -3,7 +3,6 @@
 package cfg
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,12 +26,20 @@ var (
 	KeyReposRoot     = "root"
 )
 
-// Defaults is a map of default values for config keys.
-var Defaults = map[string]string{
-	KeyDefaultHost:   "github.com",
-	KeyOutput:        OutTree,
-	KeyReposRoot:     fmt.Sprintf("~%c%s", filepath.Separator, "repositories"),
-	KeyDefaultScheme: "ssh",
+// ConfigDefaults is a struct with default values for config keys.
+type ConfigDefaults struct {
+	DefaultHost   string
+	Output        string
+	ReposRoot     []string
+	DefaultScheme string
+}
+
+// Defaults is an instance of ConfigDefaults with default values.
+var Defaults = ConfigDefaults{
+	DefaultHost:   "github.com",
+	Output:        OutTree,
+	ReposRoot:     []string{fmt.Sprintf("~%c%s", filepath.Separator, "repositories")},
+	DefaultScheme: "ssh",
 }
 
 // Values for the --out flag.
@@ -68,6 +75,7 @@ func Version() string {
 // Gitconfig represents gitconfig file.
 type Gitconfig interface {
 	Get(key string) string
+	GetAll(key string) []string
 }
 
 // Init initializes viper config registry. Values are looked up in the following order: cli flag, env variable, gitconfig file, default value.
@@ -76,41 +84,63 @@ func Init(cfg Gitconfig) {
 
 	viper.SetEnvPrefix(strings.ToUpper(GitgetPrefix))
 	viper.AutomaticEnv()
+
+	// Handle GITGET_ROOT as a path list (like PATH), using OS separator.
+	envKey := fmt.Sprintf("%s_%s", strings.ToUpper(GitgetPrefix), strings.ToUpper(KeyReposRoot))
+	if val := os.Getenv(envKey); val != "" {
+		viper.Set(KeyReposRoot, filepath.SplitList(val))
+	}
 }
 
 // readGitConfig loads values from gitconfig file into viper's registry.
 // Viper doesn't support the gitconfig format so we load it using "git config --global" command and populate a temporary "env" string,
 // which is then feed to Viper.
 func readGitconfig(cfg Gitconfig) {
-	var lines []string
-
-	// TODO: Can we somehow iterate over all possible flags?
-	for key := range Defaults {
-		if val := cfg.Get(fmt.Sprintf("%s.%s", GitgetPrefix, key)); val != "" {
-			lines = append(lines, fmt.Sprintf("%s=%s", key, val))
-		}
+	// Root is a list of roots, so it needs to be handled separately using GetAll.
+	if val := cfg.GetAll(fmt.Sprintf("%s.%s", GitgetPrefix, KeyReposRoot)); len(val) > 0 {
+		viper.SetDefault(KeyReposRoot, val)
 	}
 
-	viper.SetConfigType("env")
-
-	if err := viper.ReadConfig(bytes.NewBufferString(strings.Join(lines, "\n"))); err != nil {
-		// Log error but don't fail - configuration is optional
-		fmt.Fprintf(os.Stderr, "Warning: failed to read git config: %v\n", err)
+	// For other keys we use Get.
+	keys := []string{KeyDefaultHost, KeyOutput, KeyDefaultScheme}
+	for _, key := range keys {
+		if val := cfg.Get(fmt.Sprintf("%s.%s", GitgetPrefix, key)); val != "" {
+			viper.SetDefault(key, val)
+		}
 	}
 
 	// TODO: A hacky way to read boolean flag from gitconfig. Find a cleaner way.
 	if val := cfg.Get(fmt.Sprintf("%s.%s", GitgetPrefix, KeySkipHost)); strings.ToLower(val) == "true" {
-		viper.Set(KeySkipHost, true)
+		viper.SetDefault(KeySkipHost, true)
 	}
 }
 
 // Expand applies the variables expansion to a viper config of given key.
 // If expansion fails or is not needed, the config is not modified.
 func Expand(key string) {
+	if key == KeyReposRoot {
+		roots := viper.GetStringSlice(KeyReposRoot)
+
+		expandedRoots := make([]string, 0, len(roots))
+		for _, path := range roots {
+			if after, ok := strings.CutPrefix(path, "~"); ok {
+				if homeDir, err := os.UserHomeDir(); err == nil {
+					path = filepath.Join(homeDir, after)
+				}
+			}
+
+			expandedRoots = append(expandedRoots, path)
+		}
+
+		viper.Set(key, expandedRoots)
+
+		return
+	}
+
 	path := viper.GetString(key)
-	if strings.HasPrefix(path, "~") {
+	if after, ok := strings.CutPrefix(path, "~"); ok {
 		if homeDir, err := os.UserHomeDir(); err == nil {
-			expanded := filepath.Join(homeDir, strings.TrimPrefix(path, "~"))
+			expanded := filepath.Join(homeDir, after)
 			viper.Set(key, expanded)
 		}
 	}

--- a/pkg/cfg/config_test.go
+++ b/pkg/cfg/config_test.go
@@ -3,6 +3,7 @@ package cfg
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -29,7 +30,7 @@ func TestConfig(t *testing.T) {
 			name:        "no config",
 			configMaker: testConfigEmpty,
 			key:         KeyDefaultHost,
-			want:        Defaults[KeyDefaultHost],
+			want:        Defaults.DefaultHost,
 		},
 		{
 			name:        "value only in gitconfig",
@@ -55,14 +56,39 @@ func TestConfig(t *testing.T) {
 			key:         KeyDefaultHost,
 			want:        fromFlag,
 		},
+		{
+			name:        "multiple roots in gitconfig",
+			configMaker: testConfigMultipleRootsInGitconfig,
+			key:         KeyReposRoot,
+			want:        "root1,root2",
+		},
+		{
+			name:        "multiple roots in env var",
+			configMaker: testConfigMultipleRootsInEnvVar,
+			key:         KeyReposRoot,
+			want:        "root1,root2",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			viper.SetDefault(test.key, Defaults[KeyDefaultHost])
+			// Set manual defaults for test keys
+			switch test.key {
+			case KeyDefaultHost:
+				viper.SetDefault(test.key, Defaults.DefaultHost)
+			case KeyReposRoot:
+				viper.SetDefault(test.key, Defaults.ReposRoot)
+			}
+
 			test.configMaker(t)
 
-			got := viper.GetString(test.key)
+			var got string
+			if test.key == KeyReposRoot {
+				got = strings.Join(viper.GetStringSlice(test.key), ",")
+			} else {
+				got = viper.GetString(test.key)
+			}
+
 			if got != test.want {
 				t.Errorf("expected %q; got %q", test.want, got)
 			}
@@ -80,10 +106,28 @@ func (c *gitconfigEmpty) Get(key string) string {
 	return ""
 }
 
+func (c *gitconfigEmpty) GetAll(key string) []string {
+	return nil
+}
+
 type gitconfigValid struct{}
 
 func (c *gitconfigValid) Get(key string) string {
 	return fromGitconfig
+}
+
+func (c *gitconfigValid) GetAll(key string) []string {
+	return []string{fromGitconfig}
+}
+
+type gitconfigMultipleRoots struct{}
+
+func (c *gitconfigMultipleRoots) Get(key string) string {
+	return "root1"
+}
+
+func (c *gitconfigMultipleRoots) GetAll(key string) []string {
+	return []string{"root1", "root2"}
 }
 
 func testConfigEmpty(t *testing.T) {
@@ -114,7 +158,7 @@ func testConfigInFlag(t *testing.T) {
 	t.Setenv(envVarName, fromEnv)
 
 	cmd := cobra.Command{}
-	cmd.PersistentFlags().String(KeyDefaultHost, Defaults[KeyDefaultHost], "")
+	cmd.PersistentFlags().String(KeyDefaultHost, Defaults.DefaultHost, "")
 
 	if err := viper.BindPFlag(KeyDefaultHost, cmd.PersistentFlags().Lookup(KeyDefaultHost)); err != nil {
 		t.Fatalf("failed to bind flag: %v", err)
@@ -125,4 +169,17 @@ func testConfigInFlag(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
 	}
+}
+
+func testConfigMultipleRootsInGitconfig(t *testing.T) {
+	t.Helper()
+	Init(&gitconfigMultipleRoots{})
+}
+
+func testConfigMultipleRootsInEnvVar(t *testing.T) {
+	t.Helper()
+
+	envKey := fmt.Sprintf("%s_%s", strings.ToUpper(GitgetPrefix), strings.ToUpper(KeyReposRoot))
+	t.Setenv(envKey, strings.Join([]string{"root1", "root2"}, string(filepath.ListSeparator)))
+	Init(&gitconfigEmpty{})
 }

--- a/pkg/git/config.go
+++ b/pkg/git/config.go
@@ -18,3 +18,13 @@ func (c *ConfigGlobal) Get(key string) string {
 
 	return out
 }
+
+// GetAll reads all values for a given key from global gitconfig file. Returns empty slice when key is missing.
+func (c *ConfigGlobal) GetAll(key string) []string {
+	out, err := run.Git("config", "--global", "--get-all", key).AndCaptureLines()
+	if err != nil {
+		return nil
+	}
+
+	return out
+}

--- a/pkg/git/config_test.go
+++ b/pkg/git/config_test.go
@@ -21,6 +21,15 @@ func (c *cfgStub) Get(key string) string {
 	return out
 }
 
+func (c *cfgStub) GetAll(key string) []string {
+	out, err := run.Git("config", "--local", "--get-all", key).OnRepo(c.Path()).AndCaptureLines()
+	if err != nil {
+		return nil
+	}
+
+	return out
+}
+
 func TestGitConfig(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/git/finder.go
+++ b/pkg/git/finder.go
@@ -36,15 +36,15 @@ func Exists(path string) (bool, error) {
 
 // RepoFinder finds git repositories inside a given path and loads their status.
 type RepoFinder struct {
-	root       string
+	roots      []string
 	repos      []*Repo
 	maxWorkers int
 }
 
-// NewRepoFinder returns a RepoFinder pointed at given root path.
-func NewRepoFinder(root string) *RepoFinder {
+// NewRepoFinder returns a RepoFinder pointed at given root paths.
+func NewRepoFinder(roots []string) *RepoFinder {
 	return &RepoFinder{
-		root:       root,
+		roots:      roots,
 		maxWorkers: maxWorkers,
 	}
 }
@@ -53,50 +53,52 @@ func NewRepoFinder(root string) *RepoFinder {
 // It doesn't add repositories nested inside other git repos.
 // Returns error if root repo path can't be found or accessed.
 func (f *RepoFinder) Find() error {
-	if _, err := Exists(f.root); err != nil {
-		return fmt.Errorf("failed to access root path: %w", err)
-	}
+	for _, root := range f.roots {
+		if _, err := Exists(root); err != nil {
+			return fmt.Errorf("failed to access root path: %w", err)
+		}
 
-	err := filepath.WalkDir(f.root, func(path string, dir fs.DirEntry, err error) error {
-		// Handle walk errors
-		if err != nil {
-			// Skip permission errors but continue walking
-			if os.IsPermission(err) {
-				return nil // Skip this path but continue
+		err := filepath.WalkDir(root, func(path string, dir fs.DirEntry, err error) error {
+			// Handle walk errors
+			if err != nil {
+				// Skip permission errors but continue walking
+				if os.IsPermission(err) {
+					return nil // Skip this path but continue
+				}
+
+				return fmt.Errorf("failed to walk %s: %w", path, err)
 			}
 
-			return fmt.Errorf("failed to walk %s: %w", path, err)
+			// Only process directories
+			if !dir.IsDir() {
+				return nil
+			}
+
+			// Case 1: We're looking at a .git directory itself
+			if dir.Name() == dotgit {
+				parentPath := filepath.Dir(path)
+				f.addIfOk(parentPath)
+
+				return fs.SkipDir // Skip the .git directory contents
+			}
+
+			// Case 2: Check if this directory contains a .git subdirectory
+			gitPath := filepath.Join(path, dotgit)
+			if _, err := os.Stat(gitPath); err == nil {
+				f.addIfOk(path)
+
+				return fs.SkipDir // Skip this directory's contents since it's a repo
+			}
+
+			return nil // Continue walking
+		})
+		if err != nil {
+			return fmt.Errorf("failed to walk directory tree: %w", err)
 		}
-
-		// Only process directories
-		if !dir.IsDir() {
-			return nil
-		}
-
-		// Case 1: We're looking at a .git directory itself
-		if dir.Name() == dotgit {
-			parentPath := filepath.Dir(path)
-			f.addIfOk(parentPath)
-
-			return fs.SkipDir // Skip the .git directory contents
-		}
-
-		// Case 2: Check if this directory contains a .git subdirectory
-		gitPath := filepath.Join(path, dotgit)
-		if _, err := os.Stat(gitPath); err == nil {
-			f.addIfOk(path)
-
-			return fs.SkipDir // Skip this directory's contents since it's a repo
-		}
-
-		return nil // Continue walking
-	})
-	if err != nil {
-		return fmt.Errorf("failed to walk directory tree: %w", err)
 	}
 
 	if len(f.repos) == 0 {
-		return fmt.Errorf("%w in root path %s", ErrNoReposFound, f.root)
+		return fmt.Errorf("%w in root paths %s", ErrNoReposFound, strings.Join(f.roots, ", "))
 	}
 
 	return nil

--- a/pkg/git/finder_test.go
+++ b/pkg/git/finder_test.go
@@ -37,7 +37,7 @@ func TestFinder(t *testing.T) {
 			t.Parallel()
 			root := test.reposMaker(t)
 
-			finder := NewRepoFinder(root)
+			finder := NewRepoFinder([]string{root})
 
 			err := finder.Find()
 			if err != nil {

--- a/pkg/list.go
+++ b/pkg/list.go
@@ -16,12 +16,12 @@ var ErrInvalidOutput = errors.New("invalid output format")
 type ListCfg struct {
 	Fetch  bool
 	Output string
-	Root   string
+	Roots  []string
 }
 
 // List executes the "git list" command.
 func List(conf *ListCfg) error {
-	finder := git.NewRepoFinder(conf.Root)
+	finder := git.NewRepoFinder(conf.Roots)
 	if err := finder.Find(); err != nil {
 		return err
 	}
@@ -38,7 +38,7 @@ func List(conf *ListCfg) error {
 	case cfg.OutFlat:
 		fmt.Print(out.NewFlatPrinter().Print(printables))
 	case cfg.OutTree:
-		fmt.Print(out.NewTreePrinter().Print(conf.Root, printables))
+		printTree(conf.Roots, printables)
 	case cfg.OutDump:
 		fmt.Print(out.NewDumpPrinter().Print(printables))
 	default:
@@ -46,4 +46,26 @@ func List(conf *ListCfg) error {
 	}
 
 	return nil
+}
+
+func printTree(roots []string, printables []out.Printable) {
+	if len(roots) == 1 {
+		fmt.Print(out.NewTreePrinter().Print(roots[0], printables))
+
+		return
+	}
+
+	for _, root := range roots {
+		rootRepos := []out.Printable{}
+
+		for _, p := range printables {
+			if strings.HasPrefix(p.Path(), root) {
+				rootRepos = append(rootRepos, p)
+			}
+		}
+
+		if len(rootRepos) > 0 {
+			fmt.Print(out.NewTreePrinter().Print(root, rootRepos))
+		}
+	}
 }

--- a/pkg/out/print.go
+++ b/pkg/out/print.go
@@ -24,7 +24,7 @@ type Printable interface {
 // Errors returns a printable list of errors from the slice of Printables or an empty string if there are no errors.
 // It's meant to be appended at the end of Print() result.
 func Errors(repos []Printable) string {
-	errors := []string{}
+	errors := make([]string, 0, len(repos))
 
 	for _, repo := range repos {
 		errors = append(errors, repo.Errors()...)

--- a/pkg/url_test.go
+++ b/pkg/url_test.go
@@ -56,7 +56,7 @@ func TestURLParse(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		url, err := ParseURL(test.in, cfg.Defaults[cfg.KeyDefaultHost], cfg.Defaults[cfg.KeyDefaultScheme])
+		url, err := ParseURL(test.in, cfg.Defaults.DefaultHost, cfg.Defaults.DefaultScheme)
 		require.NoError(t, err)
 
 		got := URLToPath(*url, false)
@@ -98,7 +98,7 @@ func TestURLParseSkipHost(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		url, err := ParseURL(test.in, cfg.Defaults[cfg.KeyDefaultHost], cfg.Defaults[cfg.KeyDefaultScheme])
+		url, err := ParseURL(test.in, cfg.Defaults.DefaultHost, cfg.Defaults.DefaultScheme)
 		require.NoError(t, err)
 
 		got := URLToPath(*url, true)
@@ -126,7 +126,7 @@ func TestDefaultScheme(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		url, err := ParseURL(test.in, cfg.Defaults[cfg.KeyDefaultHost], test.scheme)
+		url, err := ParseURL(test.in, cfg.Defaults.DefaultHost, test.scheme)
 		require.NoError(t, err)
 
 		want, err := url.Parse(test.want)
@@ -149,7 +149,7 @@ func TestInvalidURLParse(t *testing.T) {
 	}
 
 	for _, test := range invalidURLs {
-		_, err := ParseURL(test, cfg.Defaults[cfg.KeyDefaultHost], cfg.Defaults[cfg.KeyDefaultScheme])
+		_, err := ParseURL(test, cfg.Defaults.DefaultHost, cfg.Defaults.DefaultScheme)
 
 		assert.Error(t, err)
 	}


### PR DESCRIPTION
- Implement scanning and listing repositories from multiple root directories
- Support multiple `--root` flags in both `git get` and `git list` commands
- Support multiple `gitget.root` entries in global Git configuration
- Support `GITGET_ROOT` as an OS-specific path list (like `PATH`)
- Update tree output to display separate trees for each configured root
- Add tests for multiple root discovery and environment variable parsing
- Update README and man pages with documentation for the new feature